### PR TITLE
add deploy doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,4 @@ pinviz.out
 pinviz.rc
 validation-report.txt
 config.json
+archive

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Credentials:
 - [Data Schema](docs/data-schema.md)
 - [Metrics](docs/metrics.md)
 - [Single Sign-On Setup](docs/single_sign_on.md)
+- [Deploy Guide](docs/deploy.md)
 
 
 ## Table of Contents
@@ -123,6 +124,12 @@ Then install the project dependencies:
 pip install -r requirements.txt
 ```
 
+For local development (includes test tools):
+
+```bash
+pip install -r requirements.dev.txt
+```
+
 **If SSH connection times out during installation** (common on slower Pi models), run installation in background:
 
 ```bash
@@ -160,6 +167,31 @@ Edit `config.py` or set environment variables:
 export DOOR_HEALTH_PORT=3667
 export DOOR_HEALTH_USERNAME=admin
 export DOOR_HEALTH_PASSWORD=changeme
+```
+
+### Local Windows Setup for Python 3.13
+
+Use [Chocolatey](https://chocolatey.org/) to install Python 3.13:
+
+```powershell
+choco install python --version=3.13 -y
+```
+
+Verify the installation:
+
+```powershell
+python --version
+# Expected: Python 3.13.x
+```
+
+Recreate the virtual environment:
+
+```powershell
+python -m venv .venv
+py -V:3.13 -m venv .venv
+.venv\Scripts\activate
+pip install -r requirements.txt
+pip install -r requirements.dev.txt
 ```
 
 ### Development on Windows (no Raspberry Pi)
@@ -203,10 +235,10 @@ eval "$(pyenv virtualenv-init -)"
 ```sh
 sudo mount -o remount,size=2G /tmp
 ```
-* install python 12
+* install python 13
 ```sh
-pyenv install 3.12
-pyenv global 3.12
+pyenv install 3.13
+pyenv global 3.13
 ```
 
 
@@ -374,7 +406,7 @@ GitHub Actions automatically runs tests on push/PR to main/develop branches.
 
 See `.github/workflows/tests.yml` for CI configuration.
 
-Tests run on Python 3.9, 3.10, and 3.11.
+Tests run on Python 3.13.
 
 ## Deployment (production)
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ Credentials:
 - [Systemd Watchdog](#systemd-watchdog)
 - [Testing](#testing)
 - [Continuous Integration](#continuous-integration)
-- [Deployment (production)](#deployment-production)
 - [Additional Documentation](#additional-documentation)
 - [Configuration Options](#configuration-options)
 - [Architecture](#architecture)
@@ -222,26 +221,6 @@ Development helper scripts:
 - Windows PowerShell: `.\scripts\run_dev.ps1 -Install` (installs dependencies and runs `start.py`)
 - Linux/macOS: `./scripts/run_dev.sh install` (installs dependencies and runs `start.py`)
 
-## Deploy
-* install github runner
-* install pyenv.
-```sh
-curl https://pyenv.run | bash
-export PATH="$HOME/.pyenv/bin:$PATH"
-eval "$(pyenv init -)"
-eval "$(pyenv virtualenv-init -)"
-```
-* increase tmp size
-```sh
-sudo mount -o remount,size=2G /tmp
-```
-* install python 13
-```sh
-pyenv install 3.13
-pyenv global 3.13
-```
-
-
 ## Running the Application
 
 ### Manual Execution
@@ -408,10 +387,6 @@ See `.github/workflows/tests.yml` for CI configuration.
 
 Tests run on Python 3.13.
 
-## Deployment (production)
-
-This repository includes a deployment workflow that builds a ZIP artifact and deploys it to a self-hosted production agent.
-
 ## Additional Documentation
 
 - [Optimizations](optimizations.md) — Performance and power optimizations for devices (Wi‑Fi power saving, etc.)
@@ -419,31 +394,6 @@ This repository includes a deployment workflow that builds a ZIP artifact and de
 - [Data Schema](data-schema.md) — Google Sheets structure and expected formats (badge list and access log)
 - [Metrics](docs/metrics.md) — SQLite ingestion/query design and metrics API behavior
 - **API Docs** (`/docs`) — Interactive Swagger UI for exploring the HTTP API (OpenAPI JSON at `/openapi.json`)
-
-
-
-Required repository secrets (set under Settings → Secrets):
-
-- `CREDS_JSON` — (optional) the full Google Service Account JSON content (will be written to `creds.json` on the target host)
-- `DOOR_HEALTH_USERNAME` — username for the health page (recommended to change from `admin`)
-- `DOOR_HEALTH_PASSWORD` — password for the health page (set a strong value)
-- `DOOR_HEALTH_PORT` — (optional) port for the health server (default 8080)
-- `DEPLOY_DIR` — (optional) directory on the target host to deploy files (default: `/opt/door`)
-
-Protection and approvals:
-
-- The `deploy` job targets the `production` environment. Configure environment protection rules in GitHub to require approvals or checks before the workflow can proceed.
-
-Behavior of the deployment workflow:
-
-- Job 1 (`build_package`) creates a ZIP containing `README.md`, all `*.md` files, `*.service` files, `version*.txt`, `main.py`, the `src_service/` package, and `requirements.txt`.
-- Job 2 (`deploy`) runs on a **self-hosted** runner (an agent you own), downloads the ZIP, extracts it to `DEPLOY_DIR` (default `/opt/door`), writes the `creds.json` file if `CREDS_JSON` is provided, creates a systemd drop-in to export `DOOR_CREDS_FILE`, `DOOR_HEALTH_USERNAME`, and `DOOR_HEALTH_PASSWORD` into the service environment, then restarts `door-app.service`.
-
-Notes & recommended follow-ups:
-
-- Secrets are never committed to the repository; they are provided to the workflow via GitHub Secrets.
-- The deployment writes the service account JSON to `creds.json` and sets `DOOR_CREDS_FILE` to point there. The service will read the config at startup.
-- You may prefer to manage secrets via a secret management system or encrypted files on the target host.
 
 ## Configuration Options
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,0 +1,251 @@
+# Deployment Guide — From Scratch
+
+End-to-end setup for the Door Controller on a fresh Raspberry Pi Zero 2 W.
+
+## Table of Contents
+- [Hardware](#hardware)
+- [1. Flash & Configure Raspberry Pi OS](#1-flash--configure-raspberry-pi-os)
+- [2. First Boot Setup](#2-first-boot-setup)
+- [3. Enable I2C (PN532 Reader)](#3-enable-i2c-pn532-reader)
+- [4. Install System Dependencies](#4-install-system-dependencies)
+- [5. Create Deployment Directory](#5-create-deployment-directory)
+- [6. Install Cloudflare Tunnel](#6-install-cloudflare-tunnel)
+- [7. Install GitHub Actions Self-Hosted Runner](#7-install-github-actions-self-hosted-runner)
+- [8. Configure GitHub Repository Secrets & Variables](#8-configure-github-repository-secrets--variables)
+- [9. Run the Deploy Workflow](#9-run-the-deploy-workflow)
+- [10. Verify the Service](#10-verify-the-service)
+- [Directory Structure](#directory-structure)
+
+---
+
+## Hardware
+
+- Raspberry Pi Zero 2 W
+- PN532 NFC/RFID Reader (I2C)
+- Relay module (GPIO pin 17)
+- 2× push buttons (GPIO pins 27 and 22)
+- 12V door latch + relay + buck converter
+- MicroSD card (8GB+)
+- Micro USB power supply (5V 2.5A+)
+
+---
+
+## 1. Flash & Configure Raspberry Pi OS
+
+Use [Raspberry Pi Imager](https://www.raspberrypi.com/software/) to flash **Raspberry Pi OS Lite (64-bit)** (Debian Bookworm) to the SD card.
+
+Before writing, open **OS Customisation** in the imager and set:
+
+| Setting | Value |
+|---|---|
+| Hostname | `doorpi` (or your choice) |
+| Username | `pi` |
+| Password | *(strong password)* |
+| SSH | Enable (password or key auth) |
+| Wi-Fi | Your network SSID + password |
+
+Write the image, insert the card, and power on the Pi.
+
+---
+
+## 2. First Boot Setup
+
+SSH into the Pi once it appears on the network:
+
+```bash
+ssh pi@doorpi.local
+```
+
+Update the system:
+
+```bash
+sudo apt update && sudo apt upgrade -y
+sudo apt install -y git unzip curl wget
+```
+
+---
+
+## 3. Enable I2C (PN532 Reader)
+
+```bash
+sudo raspi-config
+```
+
+Navigate to **Interface Options → I2C → Enable**. Reboot:
+
+```bash
+sudo reboot
+```
+
+Confirm I2C is active after reboot:
+
+```bash
+ls /dev/i2c-*
+```
+
+---
+
+## 4. Install System Dependencies
+
+```bash
+sudo apt install -y python3 python3-pip python3-venv python3-rpi-lgpio
+```
+
+> `python3-rpi-lgpio` provides the GPIO library required at runtime — it must be installed system-wide before the venv is created.
+
+---
+
+## 5. Create Deployment Directory
+
+The deploy workflow creates `DEPLOY_DIR` and its sibling `logs/`, `metrics/`, and `data/` directories automatically, then sets ownership to `pi`. No manual setup needed.
+
+---
+
+## 6. Install Cloudflare Tunnel
+
+Cloudflare Tunnel exposes the health dashboard externally without opening firewall ports.
+
+### Install cloudflared
+
+```bash
+curl -L https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-arm64.deb -o cloudflared.deb
+sudo dpkg -i cloudflared.deb
+```
+
+> For Pi Zero 2 W (ARM64). Verify the architecture with `uname -m` — should show `aarch64`.
+
+### Authenticate and create a tunnel
+
+```bash
+cloudflared tunnel login
+```
+
+### Run as a systemd service
+
+```bash
+sudo cloudflared service install
+sudo systemctl enable cloudflared
+sudo systemctl start cloudflared
+```
+
+Verify: `sudo systemctl status cloudflared`
+
+---
+
+## 7. Install GitHub Actions Self-Hosted Runner
+
+The deploy workflow runs on `self-hosted` runners — the Pi must register itself with the repository.
+
+Go to your GitHub repository → **Settings → Actions → Runners → New self-hosted runner**.
+Select **Linux / ARM64** and follow the displayed commands. They look like:
+
+```bash
+mkdir actions-runner && cd actions-runner
+curl -o actions-runner-linux-arm64-<VERSION>.tar.gz -L \
+  https://github.com/actions/runner/releases/download/v<VERSION>/actions-runner-linux-arm64-<VERSION>.tar.gz
+tar xzf actions-runner-linux-arm64-<VERSION>.tar.gz
+./config.sh --url https://github.com/<org>/<repo> --token <TOKEN>
+```
+
+> Copy the exact commands from the GitHub UI — they include a short-lived registration token.
+
+### Run the runner as a systemd service
+
+```bash
+sudo ./svc.sh install
+sudo ./svc.sh start
+```
+
+The runner will now be available to pick up deploy jobs automatically.
+
+---
+
+## 8. Configure GitHub Repository Secrets & Variables
+
+Go to **Settings → Secrets and variables → Actions**.
+
+### Secrets (sensitive values)
+
+| Secret name | Description |
+|---|---|
+| `CREDS_JSON` | Full contents of the Google service account JSON file |
+| `DOOR_HEALTH_USERNAME` | Username for the health dashboard (default: `admin`) |
+| `DOOR_HEALTH_PASSWORD` | Password for the health dashboard |
+
+### Variables (non-sensitive)
+
+| Variable name | Example value | Description |
+|---|---|---|
+| `DEPLOY_DIR` | `/opt/door` | Absolute path to the deployment directory on the Pi |
+| `DOOR_HEALTH_PORT` | `3667` | Port the health server listens on |
+
+---
+
+## 9. Run the Deploy Workflow
+
+The workflow is triggered manually:
+
+1. Go to your repository → **Actions → Deploy**
+2. Click **Run workflow** → select the branch → **Run workflow**
+
+What happens automatically:
+
+1. **Build** — calculates version via GitVersion, zips `start.py`, `src_service/`, `requirements.txt`, service files, and docs into `deploy.zip`
+2. **Deploy** (on the Pi self-hosted runner):
+   - Stops the running service
+   - Archives the old deployment
+   - Unpacks the new zip into `DEPLOY_DIR`
+   - Creates a Python venv and installs dependencies
+   - Writes `creds.json` from the `CREDS_JSON` secret
+   - Installs the systemd service and drop-in with all environment variables
+   - Restarts `door-app.service`
+
+---
+
+## 10. Verify the Service
+
+```bash
+sudo systemctl status door-app.service
+journalctl -u door-app.service -f
+```
+
+Health page (on the Pi):
+
+```
+http://localhost:3667/health
+```
+
+Or via Cloudflare Tunnel:
+
+```
+https://door.yourdomain.com/health
+```
+
+Log in with the credentials set in `DOOR_HEALTH_USERNAME` / `DOOR_HEALTH_PASSWORD`.
+
+---
+
+## Directory Structure
+
+After a successful deploy:
+
+```
+/opt/
+├── door/                  ← DEPLOY_DIR
+│   ├── start.py
+│   ├── src_service/
+│   ├── requirements.txt
+│   ├── door-app.service
+│   ├── creds.json         ← written from CREDS_JSON secret
+│   ├── local.env          ← environment variables snapshot
+│   └── venv/              ← Python virtual environment
+├── logs/
+│   ├── door_controller.log
+│   └── door_controller_watchdog_heartbeat.log
+├── metrics/
+│   └── metrics.db
+└── data/
+    └── google_sheet_data.csv
+```
+
+Environment variables are injected into the service via `/etc/systemd/system/door-app.service.d/override.conf` — edit that file (then `sudo systemctl daemon-reload && sudo systemctl restart door-app.service`) if you need to change a value between deploys.


### PR DESCRIPTION
This pull request significantly improves the project's documentation, focusing on deployment and development environment setup. The main changes include adding a comprehensive deployment guide, updating Python version requirements to 3.13, and enhancing instructions for local and Windows development.

**Documentation improvements:**

* Added a new `docs/deploy.md` file with a detailed, step-by-step deployment guide for setting up the Door Controller on a Raspberry Pi Zero 2 W, covering hardware requirements, OS flashing, dependencies, Cloudflare Tunnel, GitHub Actions runner, and verification steps.
* Linked the new deployment guide from the main `README.md` for easy access.

**Development environment updates:**

* Updated all references to Python 3.13 in the `README.md`, replacing previous Python 3.12/3.9/3.10/3.11 instructions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L206-R241) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L377-R409)
* Added instructions for setting up a local development environment with `requirements.dev.txt` and clarified how to install development dependencies.
* Introduced a dedicated section for setting up Python 3.13 on Windows using Chocolatey, including virtual environment recreation steps.