### PR TITLE
add enable script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -217,6 +217,7 @@ jobs:
 
       - name: Restart door service
         run: |
+          sudo systemctl enable door-app.service
           sudo systemctl restart door-app.service
           sudo systemctl status door-app.service --no-pager --lines=50
 


### PR DESCRIPTION
This pull request makes a small change to the deployment workflow to improve service reliability. The change ensures that the `door-app.service` is enabled to start automatically on boot.

- Deployment workflow improvement:
  * [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R220): Added a step to enable `door-app.service` with `systemctl enable` before restarting the service.