### PR TITLE
all events filter

### DIFF
--- a/src_service/metrics_storage.py
+++ b/src_service/metrics_storage.py
@@ -387,6 +387,27 @@ def query_month_events(month_key: str) -> List[Dict[str, Optional[str]]]:
         conn.close()
 
 
+def get_earliest_available_month(base_path: Optional[str] = None) -> Optional[str]:
+    """Return the earliest available month key (YYYY-MM) by scanning db files, or None."""
+    base = base_path or get_metrics_base_path()
+    if not os.path.isdir(base):
+        return None
+    earliest = None
+    for year_dir in sorted(os.listdir(base)):
+        year_path = os.path.join(base, year_dir)
+        if not os.path.isdir(year_path):
+            continue
+        for fname in sorted(os.listdir(year_path)):
+            if fname.endswith(".db") and re.match(r'^\d{4}-\d{2}\.db$', fname):
+                month_key = fname[:-3]
+                if earliest is None or month_key < earliest:
+                    earliest = month_key
+                break  # sorted — first entry is earliest in this year
+        if earliest is not None:
+            break  # found earliest year's first month
+    return earliest
+
+
 def month_events_to_csv(events: Sequence[Dict[str, Optional[str]]]) -> str:
     """Serialize event records to CSV."""
     output = StringIO()

--- a/src_service/openapi.py
+++ b/src_service/openapi.py
@@ -114,6 +114,34 @@ def get_openapi_spec(host: Optional[str] = None) -> Dict:
                     "security": [{"basicAuth": []}]
                 }
             },
+            "/api/metrics/info": {
+                "get": {
+                    "summary": "Get metrics availability info",
+                    "description": "Returns metadata about available metrics data, including the earliest available date. Requires Basic Auth.",
+                    "responses": {
+                        "200": {
+                            "description": "Metrics info (JSON)",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "object",
+                                        "properties": {
+                                            "earliest_date": {
+                                                "type": "string",
+                                                "format": "date",
+                                                "nullable": True,
+                                                "description": "Earliest available metrics date (YYYY-MM-01), or null if no data"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "401": {"description": "Unauthorized"}
+                    },
+                    "security": [{"basicAuth": []}]
+                }
+            },
             "/api/version": {
                 "get": {
                     "summary": "Get application version",

--- a/src_service/server/routes_metrics.py
+++ b/src_service/server/routes_metrics.py
@@ -4,7 +4,7 @@ import math
 from datetime import date, datetime
 from urllib.parse import parse_qs
 
-from ..metrics_storage import query_events_range, month_events_to_csv
+from ..metrics_storage import query_events_range, month_events_to_csv, get_earliest_available_month
 from .state import APPLICATION_JSON, check_rate_limit_metrics_reload, get_seconds_until_next_metrics_reload
 from ..logging_utils import get_logger
 from .auth import login_required, get_current_user
@@ -208,6 +208,7 @@ def send_metrics_page(handler, raw_query: str):
     <label>Start: <input type="date" id="startDate" value="{start_date.isoformat()}"></label>
     <label>End: <input type="date" id="endDate" value="{end_date.isoformat()}"></label>
     <button id="btnLoad">Load/Refresh</button>
+    <button id="btnAllEvents">All Events</button>
     <button id="btnClearCache">Clear Cache</button>
     <button id="btnExportCSV">Export CSV</button>
     <button id="btnExportAlerts">Export Alerts CSV</button>
@@ -487,10 +488,8 @@ async function loadMetrics() {{
   updateStatus('Loading...', 'loading');
 
   try {{
-    debugger
     // Try cache first
     let events = await getCached(start, end);
-    debugger;
     // Try to use cached segments covering requested range
     const cachedSegments = await getCachedSegments(start, end);
     if (cachedSegments && cachedSegments.length) {{
@@ -1594,6 +1593,24 @@ function exportCSV() {{
   db = await openDB();
   document.getElementById('btnLoad').addEventListener('click', loadMetrics);
   document.getElementById('btnClearCache').addEventListener('click', clearCache);
+
+  const btnAllEvents = document.getElementById('btnAllEvents');
+  if (btnAllEvents) {{
+    btnAllEvents.addEventListener('click', async () => {{
+      try {{
+        const res = await fetch('/api/metrics/info', {{ credentials: 'same-origin' }});
+        const info = await res.json();
+        if (info.earliest_date) {{
+          document.getElementById('startDate').value = info.earliest_date;
+          await loadMetrics();
+        }} else {{
+          updateStatus('No historical data found', 'error');
+        }}
+      }} catch (e) {{
+        updateStatus('Error fetching earliest date: ' + e.message, 'error');
+      }}
+    }});
+  }}
   document.getElementById('btnExportCSV').addEventListener('click', exportCSV);
   const btnExportAlerts = document.getElementById('btnExportAlerts');
   if (btnExportAlerts) {{ btnExportAlerts.addEventListener('click', () => exportTooLongCSV(latestEvents)); }}
@@ -1675,6 +1692,14 @@ function exportCSV() {{
     handler.send_header("Content-type", "text/html; charset=utf-8")
     handler.end_headers()
     handler.wfile.write(html.encode("utf-8"))
+
+
+def handle_metrics_info_api(handler) -> bool:
+    """GET /api/metrics/info - returns metadata about available metrics (e.g. earliest date)."""
+    earliest = get_earliest_available_month()
+    earliest_date = (earliest + "-01") if earliest else None
+    _write_json(handler, {"earliest_date": earliest_date})
+    return True
 
 
 def handle_metrics_reload_post(handler) -> bool:

--- a/src_service/server/server.py
+++ b/src_service/server/server.py
@@ -226,6 +226,12 @@ class RequestHandler(BaseHTTPRequestHandler):
             if routes_metrics.handle_unified_metrics_api(self, raw_query):
                 return
 
+        if path == "/api/metrics/info":
+            if not self._require_api_auth():
+                return
+            if routes_metrics.handle_metrics_info_api(self):
+                return
+
         # Authenticated API: return current application version
         if path == "/api/version":
             if not self._require_api_auth():

--- a/tests/test_health_server.py
+++ b/tests/test_health_server.py
@@ -772,7 +772,7 @@ class TestHealthServer(unittest.TestCase):
         self.config_patcher.stop()
         self.logger_patcher.stop()
 
-    @patch("src_service.server.server.HTTPServer")
+    @patch("src_service.server.server.ThreadingHTTPServer")
     def test_server_start(self, mock_http_server):
         mock_http_server.return_value.serve_forever = lambda: time.sleep(0.1)
         srv = server.HealthServer(port=8888)
@@ -789,7 +789,7 @@ class TestHealthServer(unittest.TestCase):
         srv2 = server.HealthServer()
         self.assertEqual(srv2.port, 8888)
 
-    @patch("src_service.server.server.HTTPServer")
+    @patch("src_service.server.server.ThreadingHTTPServer")
     def test_global_start_stop(self, mock_http_server):
         mock_http_server.return_value.serve_forever = lambda: time.sleep(0.1)
         import src_service.server.server as server_module


### PR DESCRIPTION
This pull request adds a new feature to expose and utilize the **earliest available metrics data date** in the system. It introduces a backend API endpoint to provide this information, updates the OpenAPI spec, and adds a UI button to let users quickly load all available events from the earliest date. Some code cleanup and utility additions are also included.

**API and Backend Enhancements:**

* Added a new function `get_earliest_available_month` in `metrics_storage.py` to determine the earliest available month of metrics data by scanning database files.
* Introduced the `/api/metrics/info` GET endpoint, returning JSON metadata about metrics availability (specifically, the earliest available date), and documented it in the OpenAPI spec. [[1]](diffhunk://#diff-bbc20a5b24581336296dbbca7b4e1355d3ffdd4450477c4debd96213eab6b9d4R117-R144) [[2]](diffhunk://#diff-9936ab989328b6062143ab597af84759f2fccb6c45914326fe0c045c8e56a267R1697-R1704) [[3]](diffhunk://#diff-3e946f2c29832f067d6d207b582f6d138492dba1989034704be995ab543c494fR229-R234)

**Frontend/UI Improvements:**

* Added an "All Events" button to the metrics page, which fetches the earliest available date from the new API and loads metrics from that date. [[1]](diffhunk://#diff-9936ab989328b6062143ab597af84759f2fccb6c45914326fe0c045c8e56a267R211) [[2]](diffhunk://#diff-9936ab989328b6062143ab597af84759f2fccb6c45914326fe0c045c8e56a267R1596-R1613)
