### PR TITLE
fix google auth for library update

### DIFF
--- a/src_service/server/auth.py
+++ b/src_service/server/auth.py
@@ -250,20 +250,21 @@ def login_required(fn):
     return wrapper
 
 
-def save_oauth_state(state: str, next_path: str) -> None:
+def save_oauth_state(state: str, next_path: str, code_verifier: Optional[str] = None) -> None:
     _OAUTH_STATE_STORE[state] = {
         "next": _sanitize_next(next_path),
         "expires_at": _now_ts() + _OAUTH_STATE_TTL_SECONDS,
+        "code_verifier": code_verifier,
     }
 
 
-def pop_oauth_state(state: str) -> Optional[str]:
+def pop_oauth_state(state: str) -> Optional[tuple]:
     data = _OAUTH_STATE_STORE.pop(state, None)
     if not data:
         return None
     if data.get("expires_at", 0) <= _now_ts():
         return None
-    return data.get("next")
+    return data.get("next"), data.get("code_verifier")
 
 
 def _normalize_list(value) -> list:

--- a/src_service/server/routes_auth.py
+++ b/src_service/server/routes_auth.py
@@ -238,7 +238,11 @@ def handle_google_login_start(handler, raw_query: str) -> None:
         prompt="select_account",
     )
 
-    save_oauth_state(state, next_path)
+    # Capture PKCE code_verifier if the library auto-generated one (google-auth-oauthlib >= 1.4.0)
+    code_verifier = getattr(flow, "code_verifier", None)
+    if code_verifier is None:
+        code_verifier = getattr(getattr(flow, "oauth2session", None), "code_verifier", None)
+    save_oauth_state(state, next_path, code_verifier)
     handler.send_response(302)
     handler.send_header("Location", auth_url)
     handler.end_headers()
@@ -248,7 +252,9 @@ def handle_google_callback(handler, raw_query: str) -> None:
     query = parse_qs(raw_query or "", keep_blank_values=True)
     state = query.get("state", [""])[0]
     code = query.get("code", [""])[0]
-    next_path = pop_oauth_state(state) or "/admin"
+    state_data = pop_oauth_state(state)
+    next_path = (state_data[0] if state_data else None) or "/admin"
+    code_verifier = state_data[1] if state_data else None
 
     if not config.get("GOOGLE_OAUTH_ENABLED"):
         send_login_page(handler, raw_query=f"next={next_path}", error_message="Google OAuth is not enabled")
@@ -306,7 +312,10 @@ def handle_google_callback(handler, raw_query: str) -> None:
             qs,
             "",
         ))
-        flow.fetch_token(authorization_response=full_url)
+        fetch_kwargs = {"authorization_response": full_url}
+        if code_verifier:
+            fetch_kwargs["code_verifier"] = code_verifier
+        flow.fetch_token(**fetch_kwargs)
         credentials = flow.credentials
         info = id_token.verify_oauth2_token(credentials.id_token, Request(), client_id)
         email = info.get("email")


### PR DESCRIPTION
This pull request updates the Google OAuth login flow to support PKCE (Proof Key for Code Exchange), improving security and compatibility with newer versions of the `google-auth-oauthlib` library. The main changes revolve around capturing and storing the PKCE `code_verifier` during the OAuth process and ensuring it is correctly used when exchanging the authorization code for tokens.

**Google OAuth PKCE Support:**

* The `save_oauth_state` and `pop_oauth_state` functions in `auth.py` now handle an optional `code_verifier`, storing it alongside the OAuth state and returning it when needed.
* In `routes_auth.py`, the Google login start handler attempts to extract the `code_verifier` from the OAuth flow (supporting both direct and nested attributes for compatibility), and stores it with the state.
* The Google callback handler retrieves both the `next_path` and `code_verifier` from the state, ensuring the `code_verifier` is available for the token exchange step.
* When fetching the OAuth token, the callback handler conditionally passes the `code_verifier` if present, enabling PKCE support during the token exchange.